### PR TITLE
feat: redirect root slugs to project pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ProjectDetail from "./pages/ProjectDetail";
 import About from "./pages/About";
 import Resume from "./pages/Resume";
 import NotFound from "./pages/NotFound";
+import ProjectRedirect from "./pages/ProjectRedirect";
 
 const queryClient = new QueryClient();
 
@@ -26,6 +27,7 @@ const App = () => (
             <Route path="/work/:slug" element={<ProjectDetail />} />
             <Route path="/about" element={<About />} />
             <Route path="/resume" element={<Resume />} />
+            <Route path="/:slug" element={<ProjectRedirect />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/pages/ProjectRedirect.tsx
+++ b/src/pages/ProjectRedirect.tsx
@@ -1,0 +1,9 @@
+import { Navigate, useParams } from "react-router-dom";
+
+const ProjectRedirect = () => {
+  const { slug } = useParams<{ slug: string }>();
+
+  return <Navigate to={`/work/${slug}`} replace />;
+};
+
+export default ProjectRedirect;


### PR DESCRIPTION
## Summary
- support root-level project slugs by redirecting them to `/work/:slug`
- new `ProjectRedirect` route handles redirect logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run format:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd58df9c8324afc0e9db1090e81e